### PR TITLE
Fixed ROR opcodes in the csv files

### DIFF
--- a/6502Disassembler/6502ops.csv
+++ b/6502Disassembler/6502ops.csv
@@ -147,8 +147,8 @@ opcode,mnemonic,addressing mode,bytes,cycles,flags
 0x6a,ROR,ACC,1,2,CZidbvN
 0x66,ROR,ZP,2,5,CZidbvN
 0x76,ROR,ZPX,2,6,CZidbvN
-0x7e,ROR,ABS,3,6,CZidbvN
-0x6e,ROR,ABSX,3,7,CZidbvN
+0x6e,ROR,ABS,3,6,CZidbvN
+0x7e,ROR,ABSX,3,7,CZidbvN
 
 0xe9,SBC,IMM,2,2,CZidbVN
 0xe5,SBC,ZP,2,3,CZidbVN

--- a/6502Disassembler/65C02ops.csv
+++ b/6502Disassembler/65C02ops.csv
@@ -198,8 +198,8 @@ opcode,mnemonic,addressing mode,bytes,cycles,flags
 0x6a,ROR,ACC,1,2,CZidbvN
 0x66,ROR,ZP,2,5,CZidbvN
 0x76,ROR,ZPX,2,6,CZidbvN
-0x7e,ROR,ABS,3,6,CZidbvN
-0x6e,ROR,ABSX,3,6/7,CZidbvN
+0x6e,ROR,ABS,3,6,CZidbvN
+0x7e,ROR,ABSX,3,6/7,CZidbvN
 
 0xe9,SBC,IMM,2,2,CZidbVN
 0xe5,SBC,ZP,2,3,CZidbVN


### PR DESCRIPTION
Hi,
the opcodes for ROR abs and ROR abs,X seemed to have been swapped.
ROR abs should be 0x6e
ROR abs,X should be 0x7e

Regards,
Juraj